### PR TITLE
Turn off some PBP policies that aren't very helpful.

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -13,18 +13,18 @@ verbose = 11
 [-Variables::ProhibitPunctuationVars]
 
 [CodeLayout::RequireTrailingCommas]
-severity = 5
+severity = 4
 
 [TestingAndDebugging::RequireUseStrict]
 equivalent_modules = Test::Routine
 
 [ValuesAndExpressions::ProhibitEmptyQuotes]
-severity = 5
+severity = 4
 
 [ValuesAndExpressions::ProhibitInterpolationOfLiterals]
 allow_if_string_contains_single_quote = 1
 allow = qq{} qq[]
-severity = 5
+severity = 4
 
 [ValuesAndExpressions::ProhibitNoisyQuotes]
-severity = 5
+severity = 4


### PR DESCRIPTION
I find the benefits of these policies to be arguable and negligible.
I spend more time making perlcritic happy than they provide for
readability or avoiding bugs.  If someone really finds `','` and `''`
hard to read we can turn them back on.

ProhibitInterpolationOfLiterals requires a special note because its
rationales are wrong.  Interpolated strings are compiled to literals
with concatenation and the compile time saved is wholly negligible
(especially for a project using Moose).

The policy cannot know if `'Foo $bar'` was intentional or not so the
rationale of communicating intent doesn't work.  On the other side,
strict will catch if `"Foo $bar"` is a mistake, but cannot catch if 
`'Foo $bar'` is a mistake and neither can be policy.