### PR TITLE
Actually use "indexed:false" logic for common files

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -300,7 +300,13 @@ has indexed => (
     required => 1,
     is       => 'rw',
     isa      => 'Bool',
-    default  => 1,
+    lazy     => 1,
+    default  => sub {
+        my ($self) = @_;
+        return 0 if $self->is_in_other_files;
+        return 0 if !$self->metadata->should_index_file( $self->path );
+        return 1;
+    },
 );
 
 =head2 level

--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -245,9 +245,7 @@ sub _build_files {
                     date         => $self->date,
                     directory    => $child->is_dir,
                     distribution => $self->distribution,
-                    indexed      => $self->metadata->should_index_file($fpath)
-                    ? 1
-                    : 0,
+
                     local_path => $child,
                     maturity   => $self->maturity,
                     metadata   => $self->metadata,

--- a/t/release/common-files.t
+++ b/t/release/common-files.t
@@ -1,0 +1,51 @@
+use Test::More;
+use strict;
+use warnings;
+
+use lib 't/lib';
+use MetaCPAN::TestHelpers;
+
+local $TODO = 'FIXME';
+
+test_release(
+    {
+        name       => 'Common-Files-1.1',
+        author     => 'BORISNAT',
+        authorized => \1,
+        first      => \1,
+        provides   => ['Common::Files'],
+        modules    => {
+            'lib/Common/Files.pm' => [
+                {
+                    name             => 'Common::Files',
+                    indexed          => \1,
+                    authorized       => \1,
+                    version          => '1.1',
+                    version_numified => 1.1,
+                    associated_pod =>
+                        'BORISNAT/Common-Files-1.1/lib/Common/Files.pm',
+                },
+            ],
+        },
+        extra_tests => sub {
+            my ($self) = @_;
+
+            {
+                my $file = $self->file_by_path('Makefile.PL');
+
+                ok !$file->indexed, 'Makefile.PL not indexed';
+                ok $file->authorized,
+                    'Makefile.PL authorized, i suppose (not *un*authorized)';
+                is $file->sloc, 1, 'sloc';
+                is $file->slop, 3, 'slop';
+
+                is scalar( @{ $file->pod_lines } ), 1, 'one pod section';
+
+                is $file->abstract, undef, 'no abstract';
+            }
+
+        },
+    }
+);
+
+done_testing;

--- a/t/release/common-files.t
+++ b/t/release/common-files.t
@@ -5,8 +5,6 @@ use warnings;
 use lib 't/lib';
 use MetaCPAN::TestHelpers;
 
-local $TODO = 'FIXME';
-
 test_release(
     {
         name       => 'Common-Files-1.1',

--- a/t/var/fakecpan/configs/common-files.yml
+++ b/t/var/fakecpan/configs/common-files.yml
@@ -1,0 +1,31 @@
+---
+name: Common-Files
+version: 1.1
+abstract: Test common archive files
+
+X_Module_Faker:
+    cpan_author: BORISNAT
+    omitted_files:
+        - Makefile.PL
+
+    append:
+        -
+            file: lib/Common/Files.pm
+            content: |
+                =head1 NAME
+
+                Common::Files - testing common files in a release
+
+                =cut
+
+        -
+            file: Makefile.PL
+            # NOTE: YAML::Tiny (CPAN::Meta::YAML) strips the blank lines.
+            content: |
+                print "hi";
+
+                =pod
+
+                some pod
+
+                =cut


### PR DESCRIPTION
#385 set "indexed: false" for common release files (things that are not modules).
It had passing unit tests, however the code was actually not getting called during indexing:

* `set_indexed` is only called for module files
* the default was being set by `meta->should_index_file` before the object was created.

This adds an integration test and moves the "default" logic into a lazy builder where I think it makes the most sense.

Any thoughts? 