### PR TITLE
Improve pod links to files in the same dist

### DIFF
--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -36,14 +36,12 @@ sub link_mappings {
 }
 
 sub resolve_pod_page_link {
-    my $self = shift;
-    my ( $module, $section ) = @_;
+    my ( $self, $module, $section ) = @_;
     my $link_map = $self->{_link_map} || {};
     if ( $module and my $link = $link_map->{$module} ) {
-        $section = $section ? "#$section" : '';
-        return $self->perldoc_url_prefix . "release/" . $link . $section;
+        $module = $link;
     }
-    $self->SUPER::resolve_pod_page_link(@_);
+    $self->SUPER::resolve_pod_page_link( $module, $section );
 }
 
 sub start_item_text {

--- a/lib/MetaCPAN/Pod/XHTML.pm
+++ b/lib/MetaCPAN/Pod/XHTML.pm
@@ -27,6 +27,25 @@ sub handle_text {
     }
 }
 
+sub link_mappings {
+    my $self = shift;
+    if (@_) {
+        $self->{_link_map} = $_[0];
+    }
+    $self->{_link_map};
+}
+
+sub resolve_pod_page_link {
+    my $self = shift;
+    my ( $module, $section ) = @_;
+    my $link_map = $self->{_link_map} || {};
+    if ( $module and my $link = $link_map->{$module} ) {
+        $section = $section ? "#$section" : '';
+        return $self->perldoc_url_prefix . "release/" . $link . $section;
+    }
+    $self->SUPER::resolve_pod_page_link(@_);
+}
+
 sub start_item_text {
 
     # see end_item_text

--- a/lib/MetaCPAN/Server/Controller/Source.pm
+++ b/lib/MetaCPAN/Server/Controller/Source.pm
@@ -32,57 +32,68 @@ sub get : Chained('index') : PathPart('') : Args {
         $c->res->body( $res->[2]->[0] );
     }
     else {
-        if ( $c->req->query_params->{permalinks} ) {
-            my $links   = {};
-            my $modules = $c->model('CPAN::File')->raw->filter(
-                {
-                    and => [
-                        { term => { release => $release } },
-                        { term => { author  => $author } },
-                        {
-                            or => [
-                                {
-                                    and => [
-                                        {
-                                            exists => {
-                                                field => 'file.module.name',
-                                            }
-                                        },
-                                        {
-                                            term => {
-                                                'file.module.indexed' => \1
-                                            }
-                                        },
-                                    ]
-                                },
-                                {
-                                    and => [
-                                        {
-                                            exists => {
-                                                field => 'file.pod.analyzed',
-                                            }
-                                        },
-                                        { term => { 'file.indexed' => \1 } },
-                                    ]
-                                },
-                            ]
-                        },
-                    ],
-                }
-                )->fields( [qw( module path documentation )] )->size(5000)
-                ->all->{hits}->{hits};
-            for my $file ( map { $_->{fields} } @$modules ) {
-                my $name = $file->{documentation} or next;
-                my ($module)
-                    = grep { $_->{name} eq $name } @{ $file->{module} };
-                my $link
+        my $permalinks = $c->req->query_params->{permalinks};
+        my $links      = {};
+        my $modules    = $c->model('CPAN::File')->raw->filter(
+            {
+                and => [
+                    { term => { release => $release } },
+                    { term => { author  => $author } },
+                    {
+                        or => [
+                            {
+                                and => [
+                                    {
+                                        exists => {
+                                            field => 'file.module.name',
+                                        }
+                                    },
+                                    {
+                                        term => {
+                                            'file.module.indexed' => \1
+                                        }
+                                    },
+                                ]
+                            },
+                            {
+                                and => [
+                                    {
+                                        exists => {
+                                            field => 'file.pod.analyzed',
+                                        }
+                                    },
+                                    { term => { 'file.indexed' => \1 } },
+                                ]
+                            },
+                        ]
+                    },
+                ],
+            }
+            )->fields( [qw( module path documentation distribution )] )
+            ->size(5000)->all->{hits}->{hits};
+        for my $file ( map { $_->{fields} } @$modules ) {
+            my $name = $file->{documentation} or next;
+            my ($module)
+                = grep { $_->{name} eq $name } @{ $file->{module} };
+
+            if ($permalinks) {
+                $links->{$name}
                     = 'release/'
                     . ( ( $module && $module->{associated_pod} )
                         || "$author/$release/$file->{path}" );
-                $links->{$name} = $link;
             }
-            $c->stash->{link_mappings} = $links;
+            elsif ( !$module ) {
+                $links->{$name}
+                    = "distribution/$file->{distribution}/$file->{path}";
+            }
+            elsif ( !$module->{authorized} || !$module->{indexed} ) {
+                $links->{$name}
+                    = 'release/'
+                    . ( $module->{associated_pod}
+                        || "$author/$release/$file->{path}" );
+            }
         }
+        $c->stash->{link_mappings} = $links;
 
         $c->stash->{path} = $file;
 

--- a/lib/MetaCPAN/Server/Controller/Source.pm
+++ b/lib/MetaCPAN/Server/Controller/Source.pm
@@ -75,8 +75,10 @@ sub get : Chained('index') : PathPart('') : Args {
                 my $name = $file->{documentation} or next;
                 my ($module)
                     = grep { $_->{name} eq $name } @{ $file->{module} };
-                my $link = ( $module && $module->{associated_pod} )
-                    || "$author/$release/$file->{path}";
+                my $link
+                    = 'release/'
+                    . ( ( $module && $module->{associated_pod} )
+                        || "$author/$release/$file->{path}" );
                 $links->{$name} = $link;
             }
             $c->stash->{link_mappings} = $links;

--- a/lib/MetaCPAN/Server/View/Pod.pm
+++ b/lib/MetaCPAN/Server/View/Pod.pm
@@ -14,6 +14,7 @@ sub process {
     my $renderer = MetaCPAN::Pod::Renderer->new;
 
     my $content = $c->res->body || $c->stash->{source};
+    my $link_mappings = $c->stash->{link_mappings};
     $content = eval { join( q{}, $content->getlines ) };
 
     my ( $body, $content_type );
@@ -36,7 +37,8 @@ sub process {
         $content_type = 'text/plain';
     }
     else {
-        $body = $self->build_pod_html( $content, $show_errors, $x_codes );
+        $body = $self->build_pod_html( $content, $show_errors, $x_codes,
+            $link_mappings );
         $content_type = 'text/html';
     }
 
@@ -45,11 +47,12 @@ sub process {
 }
 
 sub build_pod_html {
-    my ( $self, $source, $show_errors, $x_codes ) = @_;
+    my ( $self, $source, $show_errors, $x_codes, $link_mappings ) = @_;
 
     my $renderer = $self->_factory->html_renderer;
     $renderer->nix_X_codes( !$x_codes );
     $renderer->no_errata_section( !$show_errors );
+    $renderer->link_mappings($link_mappings);
 
     my $html = q{};
     $renderer->output_string( \$html );


### PR DESCRIPTION
For files inside the same dist, improve the links generated in the pod.  For files that aren't modules, use /pod/distribution/$dist/$file.  For unauthorized modules or when the permalinks request parameter is used, use /pod/release/$author/$release/$file.

This does not yet address when multiple files have the same pod name.