### PR TITLE
match 'other files' by path, not filename

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -730,7 +730,7 @@ sub is_in_other_files {
         TODO
     );
 
-    return any { $self->name eq $_ } @other;
+    return any { $self->path eq $_ } @other;
 }
 
 =head2 set_indexed

--- a/t/document/file.t
+++ b/t/document/file.t
@@ -27,7 +27,7 @@ PKG
     my $name = $args{name} || 'SomeModule.pm';
     my $file = MetaCPAN::Document::File->new(
         author       => 'CPANER',
-        path         => 'some/path',
+        path         => $name,
         release      => 'Some-Release-1',
         distribution => 'Some-Release',
         name         => $name,


### PR DESCRIPTION
The list of files given as 'other' are meant to be excluded from
indexing in the root of a dist.  Some may intentionally exist in
subdirectories (particularly in lib/) and meant to be indexed.  Instead
of matching based on the filename, match based on the full path so it
only applies to files in the root directory (so far).

Fixes CPAN-API/metacpan-web#1576