### PR TITLE
Do not index anything in a /Perl6/ directory

### DIFF
--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -123,6 +123,12 @@ sub run {
             log_error {"Dunno what $_ is"};
         }
     }
+
+    # Strip off any files in a Perl6 folder
+    # e.g. http://www.cpan.org/authors/id/J/JD/JDV/Perl6/
+    # As here we are indexing perl5 only
+    @files = grep { $_ !~ m{/Perl6/} } @files;
+
     log_info { scalar @files, " archives found" } if ( @files > 1 );
 
     # build here before we fork


### PR DESCRIPTION
As otherwise Perl6 namespaces can clash with Perl5 ones and cause oddities