### PR TITLE
WIP: cleaning up types usage

### DIFF
--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -23,7 +23,7 @@ DISTRIBUTIONS
     requirements:
       Carp 0
       ExtUtils::MakeMaker 0
-      Mouse 0.40
+      Moose 0
       perl 5.006_002
       strict 0
       warnings 0
@@ -571,6 +571,13 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  Carp-Always-0.13
+    pathname: F/FE/FERREIRA/Carp-Always-0.13.tar.gz
+    provides:
+      Carp::Always 0.13
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 0
   Carp-Assert-0.21
     pathname: N/NE/NEILB/Carp-Assert-0.21.tar.gz
     provides:
@@ -2647,7 +2654,6 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Mail::Address 0
-      Net::DNS 0
       Scalar::Util 0
       Test::More 0
       perl 5.006

--- a/lib/Catalyst/Plugin/OAuth2/Provider.pm
+++ b/lib/Catalyst/Plugin/OAuth2/Provider.pm
@@ -64,7 +64,7 @@ sub authorize : Local {
     my $uri  = URI->new($redirect_uri);
     my $code = $self->_build_code;
     $uri->query_form( { code => $code, $state ? ( state => $state ) : () } );
-    $c->user->code($code);
+    $c->user->_set_code($code);
     $c->user->put( { refresh => 1 } );
     $c->res->redirect($uri);
 }

--- a/lib/Catalyst/Plugin/Session/Store/ElasticSearch.pm
+++ b/lib/Catalyst/Plugin/Session/Store/ElasticSearch.pm
@@ -9,19 +9,19 @@ use MooseX::Types::ElasticSearch qw(:all);
 
 has _session_es => (
     required => 1,
-    is       => 'rw',
+    is       => 'ro',
     coerce   => 1,
     isa      => ES,
     default  => sub { shift->_session_plugin_config->{servers} || ':9200' }
 );
 has _session_es_index => (
     required => 1,
-    is       => 'rw',
+    is       => 'ro',
     default  => sub { shift->_session_plugin_config->{index} || 'user' }
 );
 has _session_es_type => (
     required => 1,
-    is       => 'rw',
+    is       => 'ro',
     default  => sub { shift->_session_plugin_config->{type} || 'session' }
 );
 
@@ -85,7 +85,7 @@ sub delete_expired_sessions { }
      Session
      Session::Store::ElasticSearch
  );
- 
+
  # defaults
  MyApp->config(
      'Plugin::Session' => {

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -26,7 +26,6 @@ has asciiname => (
     required => 1,
     index    => 'analyzed',
     isa      => NonEmptySimpleStr,
-    required => 0,
 );
 
 has [qw(website email)] =>
@@ -52,7 +51,6 @@ has profile => (
     isa             => Profile,
     coerce          => 1,
     type            => 'nested',
-    required        => 0,
     include_in_root => 1,
 );
 
@@ -60,7 +58,6 @@ has blog => (
     is       => 'ro',
     isa      => Blog,
     coerce   => 1,
-    required => 0,
     dynamic  => 1,
 );
 
@@ -68,34 +65,30 @@ has perlmongers => (
     is       => 'ro',
     isa      => PerlMongers,
     coerce   => 1,
-    required => 0,
     dynamic  => 1,
 );
 
 has donation => (
     is       => 'ro',
     isa      => ArrayRef [ Dict [ name => NonEmptySimpleStr, id => Str ] ],
-    required => 0,
     dynamic  => 1,
 );
 
 has [qw(city region country)] =>
-    ( is => 'ro', required => 0, isa => NonEmptySimpleStr );
+    ( is => 'ro', isa => NonEmptySimpleStr );
 
-has location => ( is => 'ro', isa => Location, coerce => 1, required => 0 );
+has location => ( is => 'ro', isa => Location, coerce => 1 );
 
 has extra => (
     is          => 'ro',
     isa         => HashRef,
     source_only => 1,
     dynamic     => 1,
-    required    => 0,
 );
 
 has updated => (
     is       => 'ro',
     isa      => 'DateTime',
-    required => 0,
 );
 
 sub _build_gravatar_url {

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -37,7 +37,10 @@ has pauseid => (
     id       => 1,
 );
 
-has user => ( is => 'rw' );
+has user => (
+    is     => 'ro',
+    writer => '_set_user',
+);
 
 has gravatar_url => (
     is      => 'ro',

--- a/lib/MetaCPAN/Document/Author.pm
+++ b/lib/MetaCPAN/Document/Author.pm
@@ -11,10 +11,8 @@ use ElasticSearchX::Model::Document;
 # load order not important
 use Gravatar::URL ();
 use MetaCPAN::Types qw(:all);
-use MetaCPAN::Util;
-use MooseX::Types::Common::String qw(NonEmptySimpleStr);
-use MooseX::Types::Moose qw( Int Num Str ArrayRef HashRef Undef);
 use MooseX::Types::Structured qw(Dict Tuple Optional);
+use MetaCPAN::Util;
 
 has name => (
     is       => 'ro',

--- a/lib/MetaCPAN/Document/Distribution.pm
+++ b/lib/MetaCPAN/Document/Distribution.pm
@@ -7,8 +7,7 @@ use namespace::autoclean;
 use Moose;
 use ElasticSearchX::Model::Document;
 
-use MetaCPAN::Types qw(BugSummary);
-use MooseX::Types::Moose qw(ArrayRef);
+use MetaCPAN::Types qw( ArrayRef BugSummary );
 
 has name => (
     is       => 'ro',

--- a/lib/MetaCPAN/Document/Distribution.pm
+++ b/lib/MetaCPAN/Document/Distribution.pm
@@ -16,7 +16,7 @@ has name => (
 );
 
 has bugs => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => BugSummary,
     dynamic => 1,
 );
@@ -33,7 +33,7 @@ sub set_first_release {
     my $release = $self->releases->sort( ["date"] )->first;
     return unless $release;
     return $release if $release->first;
-    $release->first(1);
+    $release->_set_first(1);
     $release->put;
     return $release;
 }
@@ -44,7 +44,7 @@ sub unset_first_release {
         = $self->releases->filter( { term => { "release.first" => \1 }, } )
         ->size(200)->scroll;
     while ( my $release = $releases->next ) {
-        $release->first(0);
+        $release->_set_first(0);
         $release->update;
     }
     $self->index->refresh if $releases->total;

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -12,7 +12,6 @@ use List::AllUtils qw( any );
 use MetaCPAN::Document::Module;
 use MetaCPAN::Types qw(:all);
 use MetaCPAN::Util;
-use MooseX::Types::Moose qw(ArrayRef);
 use Plack::MIME;
 use Pod::Text;
 use Try::Tiny;

--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -100,7 +100,6 @@ modules defined in that class (i.e. package declarations).
 =cut
 
 has module => (
-    required        => 0,
     is              => 'rw',
     isa             => Module,
     type            => 'nested',
@@ -512,7 +511,6 @@ C<gid>, C<size> and C<mtime>.
 has stat => (
     is       => 'ro',
     isa      => Stat,
-    required => 0,
     dynamic  => 1,
 );
 
@@ -523,8 +521,7 @@ Contains the raw version string.
 =cut
 
 has version => (
-    is       => 'ro',
-    required => 0,
+    is => 'ro',
 );
 
 =head2 version_numified
@@ -621,7 +618,6 @@ has content => (
     lazy     => 1,
     builder  => '_build_content',
     property => 0,
-    required => 0,
 );
 
 sub _build_content {
@@ -641,7 +637,6 @@ Callback that returns the content of the file as a ScalarRef.
 has content_cb => (
     is       => 'ro',
     property => 0,
-    required => 0,
     default  => sub {
         sub { \'' }
     },

--- a/lib/MetaCPAN/Document/Module.pm
+++ b/lib/MetaCPAN/Document/Module.pm
@@ -86,7 +86,6 @@ has authorized => (
 # REINDEX: make 'ro' once a full reindex has been done
 has associated_pod => (
     isa      => AssociatedPod,
-    required => 0,
     is       => 'rw',
 );
 

--- a/lib/MetaCPAN/Document/Module.pm
+++ b/lib/MetaCPAN/Document/Module.pm
@@ -70,23 +70,25 @@ has name => (
 has version => ( is => 'ro' );
 
 has indexed => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
     isa      => Bool,
     default  => 0,
+    writer   => '_set_indexed',
 );
 
 has authorized => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
     isa      => Bool,
     default  => 1,
+    writer   => '_set_authorized',
 );
 
-# REINDEX: make 'ro' once a full reindex has been done
 has associated_pod => (
-    isa      => AssociatedPod,
-    is       => 'rw',
+    isa    => AssociatedPod,
+    is     => 'ro',
+    writer => '_set_associated_pod',
 );
 
 my $bom
@@ -169,7 +171,7 @@ sub set_associated_pod {
          @$files
          #>>>
     );
-    $self->associated_pod($pod);
+    $self->_set_associated_pod($pod);
     return $pod;
 }
 

--- a/lib/MetaCPAN/Document/Rating.pm
+++ b/lib/MetaCPAN/Document/Rating.pm
@@ -7,8 +7,8 @@ use Moose;
 use ElasticSearchX::Model::Document::Types qw(:all);
 use ElasticSearchX::Model::Document;
 
-use MooseX::Types::Moose qw(Int Num Bool Str ArrayRef HashRef Undef);
-use MooseX::Types::Structured qw(Dict Tuple Optional);
+use MetaCPAN::Types qw( ArrayRef Bool Num Str );
+use MooseX::Types::Structured qw( Dict );
 
 has details => (
     is  => 'ro',

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -103,8 +103,9 @@ This is an ArrayRef of modules that are included in this release.
 =cut
 
 has provides => (
-    isa => ArrayRef [Str],
-    is => 'rw',
+    is     => 'ro',
+    isa    => ArrayRef [Str],
+    writer => '_set_provides',
 );
 
 has id => (
@@ -158,13 +159,14 @@ has resources => (
 );
 
 has abstract => (
-    is        => 'rw',
+    is        => 'ro',
     index     => 'analyzed',
     predicate => 'has_abstract',
+    writer    => '_set_abstract',
 );
 
 has dependency => (
-    is              => 'rw',
+    is              => 'ro',
     isa             => Dependency,
     coerce          => 1,
     type            => 'nested',
@@ -175,9 +177,10 @@ has dependency => (
 # The indexer scripts will upgrade it to 'latest' if it's the version in
 # 02packages or downgrade it to 'backpan' if it gets deleted.
 has status => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
     default  => 'cpan',
+    writer   => '_set_status',
 );
 
 has maturity => (
@@ -199,18 +202,19 @@ has tests => (
 );
 
 has authorized => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
     isa      => Bool,
     default  => 1,
 );
 
 has first => (
-    is       => 'rw',
+    is       => 'ro',
     required => 1,
     isa      => Bool,
     lazy     => 1,
     builder  => '_build_first',
+    writer   => '_set_first',
 );
 
 has metadata => (
@@ -222,13 +226,15 @@ has metadata => (
 );
 
 has main_module => (
-    is       => 'rw',
-    isa      => Str,
+    is     => 'ro',
+    isa    => Str,
+    writer => '_set_main_module',
 );
 
 has changes_file => (
-    is       => 'rw',
-    isa      => Str,
+    is     => 'ro',
+    isa    => Str,
+    writer => '_set_changes_file',
 );
 
 sub _build_version_numified {

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -164,7 +164,6 @@ has abstract => (
 );
 
 has dependency => (
-    required        => 0,
     is              => 'rw',
     isa             => Dependency,
     coerce          => 1,
@@ -225,13 +224,11 @@ has metadata => (
 has main_module => (
     is       => 'rw',
     isa      => Str,
-    required => 0,
 );
 
 has changes_file => (
     is       => 'rw',
     isa      => Str,
-    required => 0,
 );
 
 sub _build_version_numified {

--- a/lib/MetaCPAN/Model/Archive.pm
+++ b/lib/MetaCPAN/Model/Archive.pm
@@ -93,10 +93,11 @@ has extract_dir => (
 );
 
 has _has_extracted => (
-    is       => 'rw',
+    is       => 'ro',
     isa      => Bool,
     init_arg => undef,
     default  => 0,
+    writer   => '_set_has_extracted',
 );
 
 =head1 METHODS
@@ -142,7 +143,7 @@ sub extract {
     return $self->extract_dir if $self->_has_extracted;
 
     $self->_extractor->extract( $self->extract_dir );
-    $self->_has_extracted(1);
+    $self->_set_has_extracted(1);
 
     return $self->extract_dir;
 }

--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -57,7 +57,7 @@ has document => (
 );
 
 has file => (
-    is       => 'rw',
+    is       => 'ro',
     isa      => AbsFile,
     required => 1,
     coerce   => 1,
@@ -72,7 +72,7 @@ has files => (
 );
 
 has date => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => 'DateTime',
     lazy    => 1,
     default => sub {
@@ -81,10 +81,10 @@ has date => (
     },
 );
 
-has index => ( is => 'rw', );
+has index => ( is => 'ro' );
 
 has metadata => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => 'CPAN::Meta',
     lazy    => 1,
     builder => '_build_metadata',
@@ -106,7 +106,7 @@ has modules => (
 );
 
 has version => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Str,
     lazy    => 1,
     default => sub {
@@ -116,11 +116,11 @@ has version => (
 );
 
 has status => (
-    is  => 'rw',
-    isa => Str,
+    is     => 'ro',
+    isa    => Str,
 );
 
-has bulk => ( is => 'rw', );
+has bulk => ( is => 'ro' );
 
 =head2 run
 
@@ -132,8 +132,8 @@ probably a much cleaner way to do this.
 sub run {
     my $self = shift;
     $self->document;
-    $self->document->changes_file( $self->get_changes_file( $self->files ) );
-    $self->_set_main_module( $self->modules, $self->document );
+    $self->document->_set_changes_file( $self->get_changes_file( $self->files ) );
+    $self->set_main_module( $self->modules, $self->document );
 }
 
 sub _build_archive {
@@ -227,7 +227,7 @@ sub _build_document {
     return $document;
 }
 
-sub _set_main_module {
+sub set_main_module {
     my $self = shift;
     my ( $mod, $release ) = @_;
 
@@ -242,7 +242,7 @@ sub _set_main_module {
     if ( scalar @modules == 1 ) {
 
         # there is only one module and it will become the main_module
-        $release->main_module( $modules[0]->module->[0]->name );
+        $release->_set_main_module( $modules[0]->module->[0]->name );
         return;
     }
 
@@ -250,7 +250,7 @@ sub _set_main_module {
 
         # the module has the exact name as the ditribution
         if ( $file->module->[0]->name eq $dist2module ) {
-            $release->main_module( $file->module->[0]->name );
+            $release->_set_main_module( $file->module->[0]->name );
             return;
         }
     }
@@ -262,7 +262,7 @@ sub _set_main_module {
         $a->level <=> $b->level
             || length $a->module->[0]->name <=> length $b->module->[0]->name
     } @modules;
-    $release->main_module( $sorted_modules[0]->module->[0]->name );
+    $release->_set_main_module( $sorted_modules[0]->module->[0]->name );
 
 }
 

--- a/lib/MetaCPAN/Model/User/Account.pm
+++ b/lib/MetaCPAN/Model/User/Account.pm
@@ -21,7 +21,7 @@ ID of user account.
 
 has id => (
     id => 1,
-    is => 'rw',
+    is => 'ro',
 );
 
 =head2 identity
@@ -48,8 +48,9 @@ The code attribute is used temporarily when authenticating using OAuth.
 =cut
 
 has code => (
-    is      => 'rw',
+    is      => 'ro',
     clearer => 'clear_token',
+    writer  => '_set_code',
 );
 
 =head2 access_token
@@ -76,7 +77,7 @@ L<DateTime> when the user passed the captcha.
 =cut
 
 has passed_captcha => (
-    is  => 'rw',
+    is  => 'ro',
     isa => 'DateTime',
 );
 
@@ -127,7 +128,7 @@ after add_identity => sub {
         $self->clear_looks_human;
         my $profile = $self->index->model->index('cpan')->type('author')
             ->get( $identity->{key} );
-        $profile->user( $self->id ) if ($profile);
+        $profile->_set_user( $self->id ) if ($profile);
         $profile->put;
     }
 };

--- a/lib/MetaCPAN/Model/User/Account.pm
+++ b/lib/MetaCPAN/Model/User/Account.pm
@@ -20,9 +20,8 @@ ID of user account.
 =cut
 
 has id => (
-    id       => 1,
-    required => 0,
-    is       => 'rw',
+    id => 1,
+    is => 'rw',
 );
 
 =head2 identity

--- a/lib/MetaCPAN/Model/User/Account.pm
+++ b/lib/MetaCPAN/Model/User/Account.pm
@@ -8,9 +8,8 @@ use ElasticSearchX::Model::Document;
 
 use MetaCPAN::Model::User::Identity;
 use MetaCPAN::Types qw(:all);
-use MetaCPAN::Util;
-use MooseX::Types::Moose qw(Str ArrayRef);
 use MooseX::Types::Structured qw(Dict);
+use MetaCPAN::Util;
 
 =head1 PROPERTIES
 

--- a/lib/MetaCPAN/Pod/Renderer.pm
+++ b/lib/MetaCPAN/Pod/Renderer.pm
@@ -13,10 +13,11 @@ use Pod::POM::View::Pod;
 use Pod::Text;
 
 has perldoc_url_prefix => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Uri,
     coerce  => 1,
     default => 'https://metacpan.org/pod/',
+    writer  => '_set_perldoc_url_prefix',
 );
 
 sub markdown_renderer {
@@ -44,7 +45,7 @@ sub html_renderer {
     $parser->html_header('');
     $parser->index(1);
     $parser->no_errata_section(1);
-    $parser->perldoc_url_prefix( $self->perldoc_url_prefix );
+    $parser->_set_perldoc_url_prefix( $self->perldoc_url_prefix );
 
     return $parser;
 }

--- a/lib/MetaCPAN/Role/Fastly.pm
+++ b/lib/MetaCPAN/Role/Fastly.pm
@@ -73,20 +73,20 @@ has _surrogate_keys_to_purge => (
 # How long should the CDN cache, irrespective of
 # other cache headers
 has cdn_cache_ttl => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Int,
     default => 0,
 );
 
 # Make sure the CDN NEVER caches, ignore any other cdn_cache_ttl settings
 has cdn_never_cache => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Bool,
     default => 0,
 );
 
 has browser_max_age => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Maybe [Int],
     default => sub {undef},
 );

--- a/lib/MetaCPAN/Role/Logger.pm
+++ b/lib/MetaCPAN/Role/Logger.pm
@@ -20,7 +20,6 @@ has logger => (
     required  => 1,
     isa       => Logger,
     coerce    => 1,
-    predicate => 'has_logger',
     traits    => ['NoGetopt'],
 );
 

--- a/lib/MetaCPAN/Script/Author.pm
+++ b/lib/MetaCPAN/Script/Author.pm
@@ -23,7 +23,7 @@ Loads author info into db. Requires the presence of a local CPAN/minicpan.
 =cut
 
 has author_fh => (
-    is      => 'rw',
+    is      => 'ro',
     traits  => ['NoGetopt'],
     lazy    => 1,
     default => sub { shift->cpan . '/authors/00whois.xml' },

--- a/lib/MetaCPAN/Script/Check.pm
+++ b/lib/MetaCPAN/Script/Check.pm
@@ -40,10 +40,11 @@ has errors_only => (
 );
 
 has error_count => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Int,
     default => 0,
-    traits  => ['NoGetopt']
+    traits  => ['NoGetopt'],
+    writer  => '_set_error_count',
 );
 
 sub run {
@@ -181,7 +182,7 @@ sub check_modules {
                                 "    DATE      : $rel->{fields}->{date}";
                             };
                         }
-                        $self->error_count( $self->error_count + 1 );
+                        $self->_set_error_count( $self->error_count + 1 );
                     }
                 }
                 elsif (@files) {
@@ -201,13 +202,13 @@ sub check_modules {
                         };
                         log_warn {"    DATE       : $file->{fields}->{date}"};
                     }
-                    $self->error_count( $self->error_count + 1 );
+                    $self->_set_error_count( $self->error_count + 1 );
                 }
                 else {
                     log_error {
                         "Module $pkg [$dist] doesn't not appear in ElasticSearch!";
                     };
-                    $self->error_count( $self->error_count + 1 );
+                    $self->_set_error_count( $self->error_count + 1 );
                 }
                 last if $self->module;
             }

--- a/lib/MetaCPAN/Script/First.pm
+++ b/lib/MetaCPAN/Script/First.pm
@@ -10,7 +10,7 @@ use MetaCPAN::Types qw( Str );
 with 'MetaCPAN::Role::Script', 'MooseX::Getopt';
 
 has distribution => (
-    is            => 'rw',
+    is            => 'ro',
     isa           => Str,
     documentation => q{set the 'first' for only this distribution},
 );

--- a/lib/MetaCPAN/Script/Latest.pm
+++ b/lib/MetaCPAN/Script/Latest.pm
@@ -195,7 +195,7 @@ sub reindex {
         }
     );
 
-    $release->status($status);
+    $release->_set_status($status);
     log_info {
         $status eq 'latest' ? 'Upgrading ' : 'Downgrading ',
             'release ', $release->name || q[];

--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -250,12 +250,12 @@ sub import_archive {
         $bulk->put($file);
         if ( !$document->has_abstract && $file->abstract ) {
             ( my $module = $document->distribution ) =~ s/-/::/g;
-            $document->abstract( $file->abstract );
+            $document->_set_abstract( $file->abstract );
             $document->put;
         }
     }
     if (@provides) {
-        $document->provides( [ sort @provides ] );
+        $document->_set_provides( [ sort @provides ] );
         $document->put;
     }
     $bulk->commit;
@@ -267,7 +267,7 @@ sub import_archive {
                 . " contains unauthorized modules: "
                 . join( ",", map { $_->name } @release_unauthorized );
         };
-        $document->authorized(0);
+        $document->_set_authorized(0);
         $document->put;
     }
 

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -32,7 +32,6 @@ has github_issues => (
 
 has github_token => (
     is       => 'ro',
-    required => 0,
     lazy     => 1,
     builder  => '_build_github_token',
 );

--- a/lib/MetaCPAN/Script/Tickets.pm
+++ b/lib/MetaCPAN/Script/Tickets.pm
@@ -103,7 +103,7 @@ sub index_bug_summary {
     for my $dist ( keys %$bugs ) {
         my $doc = $dists->get($dist);
         $doc ||= $dists->new_document( { name => $dist } );
-        $doc->bugs( $bugs->{ $doc->name } );
+        $doc->_set_bugs( $bugs->{ $doc->name } );
         $bulk->put($doc);
     }
     $bulk->commit;

--- a/lib/MetaCPAN/Server/Controller/Login/OpenID.pm
+++ b/lib/MetaCPAN/Server/Controller/Login/OpenID.pm
@@ -27,7 +27,7 @@ sub _build_ua {
 }
 
 has 'sreg' => (
-    is      => 'rw',
+    is      => 'ro',
     isa     => Str,
     default => 'http://openid.net/extensions/sreg/1.1',
 );

--- a/lib/MetaCPAN/Server/Controller/User/Turing.pm
+++ b/lib/MetaCPAN/Server/Controller/User/Turing.pm
@@ -32,7 +32,7 @@ sub index_POST {
     );
 
     if ( $result->{is_valid} ) {
-        $user->passed_captcha( DateTime->now );
+        $user->_set_passed_captcha( DateTime->now );
         $user->clear_looks_human;    # rebuild
         $user->put( { refresh => 1 } );
         $self->status_ok( $c, entity => $user->meta->get_data($user) );

--- a/lib/MetaCPAN/Server/Diff.pm
+++ b/lib/MetaCPAN/Server/Diff.pm
@@ -31,7 +31,10 @@ has structured => (
     builder => '_build_structured',
 );
 
-has numstat => ( is => 'rw' );
+has numstat => (
+    is     => 'ro',
+    writer => '_set_numstat',
+);
 
 has relative => (
     is       => 'ro',
@@ -60,7 +63,7 @@ sub _build_raw {
         \$raw
     );
     ( my $stats = $raw ) =~ s/^([^\n]*\0).*$/$1/s;
-    $self->numstat($stats);
+    $self->_set_numstat($stats);
     $raw = substr( $raw, length($stats) );
     return $raw;
 }

--- a/lib/MetaCPAN/Server/User.pm
+++ b/lib/MetaCPAN/Server/User.pm
@@ -8,8 +8,9 @@ use Moose;
 extends 'Catalyst::Authentication::User';
 
 has obj => (
-    is  => 'rw',
-    isa => 'MetaCPAN::Model::User::Account',
+    is     => 'ro',
+    isa    => 'MetaCPAN::Model::User::Account',
+    writer => '_set_obj',
 );
 
 sub get_object { shift->obj }
@@ -23,13 +24,13 @@ sub for_session {
 sub from_session {
     my ( $self, $c, $id ) = @_;
     my $user = $c->model('User::Account')->get($id);
-    $self->obj($user) if ($user);
+    $self->_set_obj($user) if ($user);
     return $user ? $self : undef;
 }
 
 sub find_user {
     my ( $self, $auth ) = @_;
-    $self->obj( $auth->{user} );
+    $self->_set_obj( $auth->{user} );
     return $self;
 }
 

--- a/lib/MetaCPAN/Types/Internal.pm
+++ b/lib/MetaCPAN/Types/Internal.pm
@@ -8,8 +8,8 @@ use ElasticSearchX::Model::Document::Types qw(:all);
 use JSON;
 use MooseX::Getopt::OptionTypeMap;
 use MooseX::Types::Common::String qw(NonEmptySimpleStr);
-use MooseX::Types::Moose qw( ArrayRef Bool HashRef Item Int Num Str Undef );
-use MooseX::Types::Structured qw(Dict Tuple Optional);
+use MooseX::Types::Moose qw( ArrayRef HashRef Item Int Str );
+use MooseX::Types::Structured qw(Dict Optional);
 
 use MooseX::Types -declare => [
     qw(

--- a/t/lib/MetaCPAN/Tests/Model.pm
+++ b/t/lib/MetaCPAN/Tests/Model.pm
@@ -83,7 +83,6 @@ has data => (
 has _expectations => (
     is        => 'ro',
     isa       => HashRef,
-    predicate => 'has_expectations',
     init_arg  => '_expect',
 );
 


### PR DESCRIPTION
Just removing some direct imports we already have through `MetaCPAN::Types`.

This is still open because:
The one I couldn't remove was uses of `MooseX::Types::Structured` since it's not playing nicely with `MooseX::Types::Combine` - we should probably report this or find a workaround, for now having it in the list of `provide_types_from` seems meaningless.
Any thoughts on this?