### PR TITLE
rework set_first_release + add first script to tests

### DIFF
--- a/lib/MetaCPAN/Script/Release.pm
+++ b/lib/MetaCPAN/Script/Release.pm
@@ -275,10 +275,6 @@ sub import_archive {
     # update 'first' value
     $document->set_first;
     $document->put;
-
-    sleep 2
-        if defined $ENV{'METACPAN_SERVER_CONFIG_LOCAL_SUFFIX'}
-        and $ENV{'METACPAN_SERVER_CONFIG_LOCAL_SUFFIX'} eq 'testing';
 }
 
 sub _build_backpan_index {

--- a/t/00_setup.t
+++ b/t/00_setup.t
@@ -81,6 +81,7 @@ copy( $src_dir->file('bugs.tsv'), $fakecpan_dir->file('bugs.tsv') );
 
 $server->index_releases;
 $server->set_latest;
+$server->set_first;
 $server->index_authors;
 $server->index_cpantesters;
 

--- a/t/lib/MetaCPAN/TestServer.pm
+++ b/t/lib/MetaCPAN/TestServer.pm
@@ -6,6 +6,7 @@ use CPAN::Repository::Perms;
 use MetaCPAN::Script::Author;
 use MetaCPAN::Script::CPANTesters ();
 use MetaCPAN::Script::Latest;
+use MetaCPAN::Script::First;
 use MetaCPAN::Script::Mapping;
 use MetaCPAN::Script::Release;
 use MetaCPAN::Server ();
@@ -182,6 +183,13 @@ sub set_latest {
     local @ARGV = ('latest');
     ok( MetaCPAN::Script::Latest->new_with_options( $self->_config )->run,
         'latest' );
+}
+
+sub set_first {
+    my $self = shift;
+    local @ARGV = ('first');
+    ok( MetaCPAN::Script::First->new_with_options( $self->_config )->run,
+        'first' );
 }
 
 sub index_authors {


### PR DESCRIPTION
this change will prevent the race between setting all releases to
first=0 and then setting first=1 based on a query that depends
on previous put to finish on ES level.

it adds a run of MetaCPAN::Script::First to the setup test,
to ensure all releases are indexed correctly ('first'-wise)
before running the other tests.