### PR TITLE
Fix 'documentation' mapping

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -73,7 +73,10 @@ sub _build_section {
 has abstract => (
     is => 'ro',
 
-    #    isa     => Maybe[Str],
+    # isa is commented as it affect the type mapping
+    # see https://github.com/CPAN-API/cpan-api/pull/484
+    # -- Mickey
+    # isa => Maybe[Str],
     lazy    => 1,
     builder => '_build_abstract',
     index   => 'analyzed',
@@ -294,11 +297,15 @@ set to C<undef>.
 =cut
 
 has documentation => (
-    is        => 'ro',
-    isa       => Maybe [Str],
+    is => 'ro',
+
+    # isa is commented as it affect the type mapping
+    # see https://github.com/CPAN-API/cpan-api/pull/484
+    # -- Mickey
+    # isa => Maybe [Str],
     lazy      => 1,
-    builder   => '_build_documentation',
     index     => 'analyzed',
+    builder   => '_build_documentation',
     predicate => 'has_documentation',
     analyzer  => [qw(standard camelcase lowercase edge edge_camelcase)],
     clearer   => 'clear_documentation',

--- a/lib/MetaCPAN/Document/File/Set.pm
+++ b/lib/MetaCPAN/Document/File/Set.pm
@@ -388,7 +388,7 @@ sub autocomplete {
                 }
             }
         }
-    )->sort( [ '_score', 'module.name.lowercase' ] );
+    )->sort( [ '_score', 'documentation' ] );
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/t/server/controller/search/autocomplete.t
+++ b/t/server/controller/search/autocomplete.t
@@ -23,9 +23,9 @@ test_psgi app, sub {
                 Multiple::Modules::A
                 Multiple::Modules::B
                 Multiple::Modules::RDeps
+                Multiple::Modules::Tester
                 Multiple::Modules::RDeps::A
                 Multiple::Modules::RDeps::Deprecated
-                Multiple::Modules::Tester
                 )
             ],
             'results are sorted lexically by module name + length'


### PR DESCRIPTION
This fix will change the 'documentation' mapping from:
```
    "documentation" : {
          "type" : "string"
    }
```
to:
```
    "documentation" : {
        "fields" : {
           "camelcase" : {
              "store" : true,
              "analyzer" : "camelcase",
              "type" : "string"
           },
           "lowercase" : {
              "analyzer" : "lowercase",
              "type" : "string",
              "store" : true
           },
           "edge" : {
              "analyzer" : "edge",
              "type" : "string",
              "store" : true
           },
           "analyzed" : {
              "analyzer" : "standard",
              "type" : "string",
              "fielddata" : {
                 "format" : "disabled"
              },
              "store" : true
           },
           "edge_camelcase" : {
              "store" : true,
              "type" : "string",
              "analyzer" : "edge_camelcase"
           }
        },
        "ignore_above" : 2048,
        "index" : "not_analyzed",
        "type" : "string"
     }
```
This change will also restore the original behavior of `autocomplete`
and fix the test t/server/controller/search/autocomplete.t
It is also needed to fix a test in the metacpan-web repo.