### PR TITLE
Put description & abstract info into ES

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -71,7 +71,8 @@ sub _build_section {
 }
 
 has abstract => (
-    is => 'ro',
+    required => 1,
+    is       => 'ro',
 
     # isa is commented as it affect the type mapping
     # see https://github.com/CPAN-API/cpan-api/pull/484
@@ -173,10 +174,11 @@ whitespaces and POD commands.
 =cut
 
 has description => (
-    is      => 'ro',
-    lazy    => 1,
-    builder => '_build_description',
-    index   => 'analyzed',
+    required => 1,
+    is       => 'ro',
+    lazy     => 1,
+    builder  => '_build_description',
+    index    => 'not_analyzed',
 );
 
 sub _build_description {


### PR DESCRIPTION
I can't recall why we removed it, but it is now missing
in metacpan-web (+tests)