### PR TITLE
remove gid & uid from file stat

### DIFF
--- a/lib/MetaCPAN/Document/File.pm
+++ b/lib/MetaCPAN/Document/File.pm
@@ -573,8 +573,8 @@ sub _build_slop {
 
 =head2 stat
 
-L<File::stat> info of the archive file. Contains C<mode>, C<uid>,
-C<gid>, C<size> and C<mtime>.
+L<File::stat> info of the archive file. Contains C<mode>,
+C<size> and C<mtime>.
 
 =cut
 

--- a/lib/MetaCPAN/Document/Release.pm
+++ b/lib/MetaCPAN/Document/Release.pm
@@ -89,8 +89,8 @@ See L<CPAN::Meta::Spec/license>.
 
 =head2 stat
 
-L<File::stat> info of the archive file. Contains C<mode>, C<uid>,
-C<gid>, C<size> and C<mtime>.
+L<File::stat> info of the archive file. Contains C<mode>,
+C<size> and C<mtime>.
 
 =head2 first
 

--- a/lib/MetaCPAN/Model/Release.pm
+++ b/lib/MetaCPAN/Model/Release.pm
@@ -186,7 +186,7 @@ sub _build_document {
     my $self = shift;
 
     my $st = $self->file->stat;
-    my $stat = { map { $_ => $st->$_ } qw(mode uid gid size mtime) };
+    my $stat = { map { $_ => $st->$_ } qw(mode size mtime) };
 
     my $meta         = $self->metadata;
     my $dependencies = $self->dependencies;
@@ -309,7 +309,7 @@ sub _build_files {
             my $relative = $child->relative($extract_dir);
             my $stat     = do {
                 my $s = $child->stat;
-                +{ map { $_ => $s->$_ } qw(mode uid gid size mtime) };
+                +{ map { $_ => $s->$_ } qw(mode size mtime) };
             };
             return if ( $relative eq q{.} );
             ( my $fpath = "$relative" ) =~ s/^.*?\///;

--- a/lib/MetaCPAN/Types/Internal.pm
+++ b/lib/MetaCPAN/Types/Internal.pm
@@ -40,8 +40,6 @@ coerce Blog, from HashRef, via { [$_] };
 subtype Stat,
     as Dict [
     mode  => Int,
-    uid   => Int,
-    gid   => Int,
     size  => Int,
     mtime => Int
     ];


### PR DESCRIPTION
from IRC:
```
20:39:06 � ranguard� any one know why gid and uid is in {stat}, other than someone not cleaning it out - e.g. 
                     https://api.metacpan.org/module/OALDERS/ElasticSearchX-Model-1.0.0/lib/ElasticSearchX/Model/Bulk.pm 

01:47:22 � oalders� ranguard: good question. no reason to keep that info
```